### PR TITLE
get_facts Serial number retrieval fails

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -109,7 +109,7 @@ class ROSDriver(NetworkDriver):
             'hostname': identity['name'],
             'fqdn': u'',
             'os_version': resource['version'],
-            'serial_number': routerboard.get('serial_number', ''),
+            'serial_number': routerboard.get('serial-number', ''),
             'interface_list': napalm_base.utils.string_parsers.sorted_nicely(
                 tuple(iface['name'] for iface in interfaces)
             ),


### PR DESCRIPTION
Typo - Replace underscore with dash.

Tested on ROS 6.39.1 (stable).

```
$ pip show napalm-ros
Name: napalm-ros
Version: 0.2.2
Summary: Network Automation and Programmability Abstraction Layer driver for Mikrotik ROS
Home-page: https://github.com/napalm-automation/napalm-ros
Author: Matt Ryan
Author-email: inetuid@gmail.com
License: UNKNOWN
Location: /usr/local/lib/python2.7/site-packages
Requires: chainmap, librouteros, napalm-base
```
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
