### PR TITLE
Fix serial number typo

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -109,7 +109,7 @@ class ROSDriver(NetworkDriver):
             'hostname': identity['name'],
             'fqdn': u'',
             'os_version': resource['version'],
-            'serial_number': routerboard.get('serial_number', ''),
+            'serial_number': routerboard.get('serial-number', ''),
             'interface_list': napalm_base.utils.string_parsers.sorted_nicely(
                 tuple(iface['name'] for iface in interfaces)
             ),

--- a/test/unit/mocked_data/test_get_facts/pc/_system_resource_print.json
+++ b/test/unit/mocked_data/test_get_facts/pc/_system_resource_print.json
@@ -5,7 +5,7 @@
             "uptime": "1m30s",
             "version": "6.33.3 (stable)",
             "platform": "MikroTik",
-            "serial_number": "",
+            "serial-number": "",
             "board-name": "x86"
         }
     ]


### PR DESCRIPTION
Mikrotik stores `serial_number` as `serial-number`. Fix this in `get_facts()`.

Refers to #51 