### PR TITLE
Incomplete entries were causing issues

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -41,7 +41,7 @@ class ROSDriver(NetworkDriver):
     def get_arp_table(self):
         arp_table = []
         for entry in self.api('/ip/arp/print'):
-            if not 'mac-address' in entry:
+            if 'mac-address' not in entry:
                 continue
             arp_table.append(
                 {

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -41,6 +41,8 @@ class ROSDriver(NetworkDriver):
     def get_arp_table(self):
         arp_table = []
         for entry in self.api('/ip/arp/print'):
+            if not 'mac-address' in entry:
+                continue
             arp_table.append(
                 {
                     'interface': entry['interface'],

--- a/test/unit/mocked_data/test_get_arp_table/normal/_ip_arp_print.json
+++ b/test/unit/mocked_data/test_get_arp_table/normal/_ip_arp_print.json
@@ -22,6 +22,17 @@
         "invalid": false,
         "mac-address": "0A:00:27:00:00:00",
         "address": "192.168.56.1"
+    },
+    {
+        "complete": false,
+        "address": "192.168.0.220",
+        "dynamic": true,
+        "invalid": false,
+        "disabled": false,
+        ".id": "*13",
+        "published": false,
+        "interface": "ether1",
+        "DHCP": false
     }
     ]
 }


### PR DESCRIPTION
```
{u'complete': False, u'address': u'192.168.0.220', u'dynamic': True, u'invalid': False, u'disabled': False, u'.id': u'*13', u'published': False, u'interface': u'ether1', u'DHCP': False}
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "napalm_ros/ros.py", line 48, in get_arp_table
    'mac': cast_mac(entry['mac-address']),
KeyError: u'mac-address'
```
